### PR TITLE
Refine header spacing in home and preview pages

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -138,7 +138,7 @@ export default function Home() {
             </header>
             {isStandalone ?
                 hasContacts ?
-                    <div className="mt-8 flex flex-col items-center space-y-4">
+                    <div className="mt-16 flex flex-col items-center space-y-4">
                         {/* Render all contacts that have data */}
                         {contacts
                             .filter(c => c.formValues?.name && c.formValues?.vibe)
@@ -157,8 +157,8 @@ export default function Home() {
                             <Button className="mt-4" onClick={create}>+ New contact</Button>
                         )}
                     </div>
-                    : canAddContact ? <Button className="mt-8" onClick={create}>+ New contact</Button> : null
-                : <div className="mt-8 flex flex-col items-center">
+                    : canAddContact ? <Button className="mt-16" onClick={create}>+ New contact</Button> : null
+                : <div className="mt-16 flex flex-col items-center">
                     <Button className="mb-4" onClick={pressInstallButton}>Install app</Button>
                     <TextButton onClick={togglePrivacyModal}>Privacy</TextButton>
                 </div>

--- a/pages/preview.js
+++ b/pages/preview.js
@@ -361,7 +361,7 @@ export default function Preview() {
         </div>;
 
     return (
-        <Page className="pt-16 opacity-0"
+        <Page className="pt-8 opacity-0"
             style={loading ? null : { "opacity": 1 }}>
             <nav className="fixed z-10 top-0 w-full p-4 flex justify-between">
                 <TextButton className={styles.home} onClick={home}>Home</TextButton>


### PR DESCRIPTION
Adjusts vertical margins and padding to improve layout balance. Increases home page top margin from 8 to 16 units for better spacing from header. Decreases preview page top padding from 16 to 8 units for proportional layout. Refinement following the 3-contact limit feature.