### PR TITLE
Adjust margin on index page contacts section

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -138,7 +138,7 @@ export default function Home() {
             </header>
             {isStandalone ?
                 hasContacts ?
-                    <div className="mt-16 flex flex-col items-center space-y-4">
+                    <div className="mt-12 flex flex-col items-center space-y-4">
                         {/* Render all contacts that have data */}
                         {contacts
                             .filter(c => c.formValues?.name && c.formValues?.vibe)


### PR DESCRIPTION
Change margin from mt-16 to mt-12 on the contacts display area when in standalone mode. This improves the spacing between the header and contact cards.