### PR TITLE
feat: split install prompt analytics into separate metrics

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -180,10 +180,12 @@ export default function Home() {
         installPrompt.prompt();
         // Wait for the user to respond to the prompt ("accepted" | "dismissed")
         const { outcome } = await installPrompt.userChoice;
-        // Prompt install analytics
-        gtag("event", "android_install_prompt", {
-            "outcome": outcome
-        });
+        // Log install prompt outcome as separate metrics
+        if (outcome === 'accepted') {
+            gtag("event", "install_prompt_accepted");
+        } else if (outcome === 'dismissed') {
+            gtag("event", "install_prompt_dismissed");
+        }
         // Discard used prompt
         setInstallPrompt(null);
     }


### PR DESCRIPTION
Logs install prompt outcomes as distinct events (install_prompt_accepted and install_prompt_dismissed) instead of a single event with an outcome parameter. This enables clearer funnel analysis and conversion tracking in Google Analytics.