### PR TITLE
fix: smooth transition between contact preview and edit pane

### DIFF
--- a/components/EditPane.js
+++ b/components/EditPane.js
@@ -8,9 +8,13 @@ export default function EditPane(props) {
 
     useEffect(() => {
         const paneNode = pane.current;
-        paneNode.style.opacity = 1;
+        // Delay fade-in to let Contact fade out first (300ms duration)
+        const timer = setTimeout(() => {
+            paneNode.style.opacity = 1;
+        }, 150);
 
         return () => {
+            clearTimeout(timer);
             paneNode.style.opacity = 0;
         }
     }, [])


### PR DESCRIPTION
Delay EditPane fade-in by 150ms so Contact fades out first, creating a seamless crossfade instead of overlapping opacity changes.