### PR TITLE
fix: prevent layout flash on index load by detecting standalone mode early

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -20,6 +20,15 @@ import { migrateFromSecureStorage } from '../utils/migration.js';
 export const StorageContext = createContext(null);
 
 /**
+ * Check if running in standalone (PWA) mode.
+ * Must be checked on client-side only.
+ */
+function checkIsStandalone() {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia("(display-mode: standalone)").matches;
+}
+
+/**
  * Migrate from old single-contact structure to new multi-contact array.
  * 
  * WHY: Existing users have data in formValues/linkValues keys. We need to
@@ -77,6 +86,7 @@ function MyApp({ Component, pageProps }) {
   const [loading, setLoading] = useState(true);
   const [contacts, _setContacts] = useState([]);
   const [storageError, setStorageError] = useState(false);
+  const [isStandalone, setIsStandalone] = useState(false);
 
   /**
    * Save contacts to storage and update state.
@@ -168,9 +178,12 @@ function MyApp({ Component, pageProps }) {
 
   // Load storage and set state once on mount
   useEffect(() => {
+    // Check standalone mode first (before any async operations)
+    setIsStandalone(checkIsStandalone());
+
     // Run legacy migration first (react-secure-storage → plain localStorage)
     migrateFromSecureStorage();
-    
+
     // Run multi-contact migration (single contact → array)
     migrateToMultiContact();
 
@@ -202,6 +215,7 @@ function MyApp({ Component, pageProps }) {
   const contextValue = {
     // Data
     contacts,
+    isStandalone,
     // Operations
     getContact,
     setContact,

--- a/pages/index.js
+++ b/pages/index.js
@@ -75,7 +75,7 @@ function SortableContact({ contact }) {
 }
 
 export default function Home() {
-    const { contacts, canAddContact, reorderContacts } = useContext(StorageContext);
+    const { contacts, canAddContact, reorderContacts, isStandalone } = useContext(StorageContext);
 
     // Configure sensors for drag-and-drop
     const sensors = useSensors(
@@ -102,7 +102,7 @@ export default function Home() {
         }
     };
 
-    const [isStandalone, setIsStandalone] = useState(false);
+    const [mounted, setMounted] = useState(false);
     const [os, setOs] = useState(null);
     const [isPromptable, setIsPromptable] = useState(false);
     const [installPrompt, setInstallPrompt] = useState(null);
@@ -114,6 +114,8 @@ export default function Home() {
     const el = useRef(null);
 
     useEffect(() => {
+        // Trigger fade-in after mount
+        setMounted(true);
         // Initialize headline shuffle (lazy loaded)
         let typed = null;
         import('typed.js').then((Typed) => {
@@ -144,10 +146,8 @@ export default function Home() {
         };
         window.addEventListener('appinstalled', handleAppInstalled);
 
-        // Standalone mode media query
-        if (window.matchMedia("(display-mode: standalone)").matches) {
-            setIsStandalone(true);
-        } else {
+        // Detect OS for install instructions (only needed when not in standalone mode)
+        if (!window.matchMedia("(display-mode: standalone)").matches) {
             const userAgentString = window.navigator.userAgent.toLowerCase();
             // iOS check
             if (/iphone|ipad|ipod/.test(userAgentString)) {
@@ -211,7 +211,8 @@ export default function Home() {
     const hasContacts = contacts && contacts.length > 0 && contacts.some(c => c.formValues?.name && c.formValues?.vibe);
 
     return (
-        <Page className="justify-center bg-slate-100">
+        <Page className="justify-center bg-slate-100 opacity-0"
+            style={mounted ? { opacity: 1 } : null}>
             <div className={styles.siteCode}></div>
             <header className="text-center text-slate-600">
                 <p className="mt-6 mb-6 text-4xl leading-tight">Share your contact&nbsp;info


### PR DESCRIPTION
Moves standalone mode detection from index.js to _app.js so it's determined alongside initial contact data loading, eliminating the flash between web UI and app UI on PWA devices. Adds fade-in animation for initial page load for a smooth transition from blank page to content.